### PR TITLE
Update ablesci.py

### DIFF
--- a/ablesci.py
+++ b/ablesci.py
@@ -11,10 +11,10 @@ import base64
 import urllib.parse
 
 # 添加bark推送
-bark_push = os.environ.get("BARK_PUSH", "")
-bark_icon = os.environ.get("BARK_ICON", "")
+bark_push = "https://api.day.app/{key}" #(自建推送的自行替换整段url，非自建只需替换key即可)
+bark_group = "AbleSci"
+bark_icon = "https://staticres.ablesci.com/apple-touch-icon.png"
 bark_sound = os.environ.get("BARK_SOUND", "")
-bark_group = os.environ.get("BARK_GROUP", "")
 
 # 添加钉钉推送
 dingtalk_token = os.environ.get("DD_BOT_TOKEN", "")
@@ -83,7 +83,7 @@ def send_bark_notification(results):
     }
 
     # 发送POST请求（JSON格式）
-    bark_url = f"https://api.day.app/{bark_push}"
+    bark_url = f"{bark_push}"
     try:
         resp = requests.post(bark_url, json=params)
         resp.raise_for_status()


### PR DESCRIPTION
修改bark推送信息，默认是推送到青龙系统信息group比较杂不好看，修改了icon。
有些人的bark推送是自建的，域名不一样，这样可以比较方便修改。
sound感觉没必要，其实可以删掉，没啥人用我感觉。
